### PR TITLE
Fix pip version to 2.7.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -49,7 +49,7 @@ function install_toolchain() {
     fi
     if ! platformio --version &>/dev/null; then
         echo 'Installing platformio...'
-        pip install platformio
+        pip2.7 install platformio
     fi
     if ! [[ -d "${INSTALL_DIR}" ]]; then
         mkdir "${INSTALL_DIR}"


### PR DESCRIPTION
Platformio currently only supports python 2.7 not 3.0. This leads to issues when having both python2 and python3 installed. 

I ran into the following error:

```
Installing platformio...
Collecting platformio
  Downloading platformio-3.5.0.tar.gz (91kB)
    100% |████████████████████████████████| 92kB 2.5MB/s 
    Complete output from command python setup.py egg_info:
    PlatformIO Core v3.5.0 does not run under Python version 3.6.4.
    Minimum supported version is 2.7, please upgrade Python.
    Python 3 is not yet supported.
    
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-8vfq5sgq/platformio/
```