### PR TITLE
install pip packages as user

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -57,7 +57,7 @@ function install_toolchain() {
     fi
     if ! platformio --version &>/dev/null; then
         echo 'Installing platformio...'
-        pip install platformio
+        pip install platformio --user
     fi
     if ! [[ -d "${INSTALL_DIR}" ]]; then
         mkdir "${INSTALL_DIR}"


### PR DESCRIPTION
When running the script, I'd rather not give `sudo` to it, just like rust usually doesn't install to a shared directory.

Tested to successfully install (Linux mint: `Linux #37~16.04.1-Ubuntu SMP x86_64 GNU/Linux`). :ok_hand: 
