### PR TITLE
add working Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM ubuntu:16.04
+
+RUN apt-get update && apt-get install -y git curl gcc libssl-dev pkg-config python-pip cmake
+RUN curl https://sh.rustup.rs -sSf > rustup.sh && chmod +x rustup.sh
+RUN ./rustup.sh -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+WORKDIR /build
+
+RUN git clone https://github.com/emosenkis/esp-rs
+
+WORKDIR /build/esp-rs
+
+RUN ./build.sh --install


### PR DESCRIPTION
I created a Dockerfile for this project. I haven't personally set up any CI pipelines before, but this should help towards #13.

This Docker image just installs esp-rs using `./build.sh --install`. It can't run any tests yet (because there are none), but it's a good way to keep track of dependencies and ensure that the project at least builds successfully.

Of note - I had to install `rustup` manually outside of `build.sh` because it's impossible to use an interactive prompt in a Docker build process, and I couldn't pass the `-y` flag to the `rustup` otherwise.