### PR TITLE
Modified shebang to /usr/bin/env bash

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e -u -o pipefail
 


### PR DESCRIPTION
This change was made so the the script can run on systems where bash is
not found under /bin.