### PR TITLE
Update Dockerfile for platformio user install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,12 @@ RUN curl https://sh.rustup.rs -sSf > rustup.sh && chmod +x rustup.sh
 RUN ./rustup.sh -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
+ENV HOME="/root"
+ENV PATH="${HOME}/.local/bin:${PATH}"
+
 WORKDIR /build
 
-RUN git clone https://github.com/emosenkis/esp-rs
+COPY . /build/esp-rs
 
 WORKDIR /build/esp-rs
 


### PR DESCRIPTION
https://github.com/emosenkis/esp-rs/commit/d75eafa3c8ee0c4a12f53e9a2720bbe4db870e9a broke the Dockerfile since the pip user install path isn't added by default. This adds it back to `$PATH`.

I also updated the Dockerfile to copy the current repo's source rather than just whatever version happens to be on Github at the time.