### PR TITLE
Pin libc version to 0.2.42

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -105,7 +105,7 @@ function init_project() {
         cargo init
         echo 'embedded-hal = { version = "0.2.1", features = ["unproven"] }' >> Cargo.toml
         echo 'esp8266-hal = "0.0.1"' >> Cargo.toml
-        echo 'libc = { version = "0.2.22", default-features = false }' >> Cargo.toml
+        echo 'libc = { version = "=0.2.42", default-features = false }' >> Cargo.toml
     fi
     if ! grep -qs no_std src/lib.rs ; then
         echo 'Generating src/lib.rs'


### PR DESCRIPTION
The latest version of libc which is incompatible with mrustc and causes the following errors, 

```
Transpiling project with mrustc
+ rm -f lib/generated/libesp_temperature-0_1_0.hir.o.c
+ /home/russell/.esp-rs/mrustc/tools/bin/minicargo /home/russell/projects/esp-temperature --script-overrides /home/russell/.esp-rs/mrustc/script-overrides/stable-1.19.0-linux/ -L /home/russell/.esp-rs/mrustc/output/ --vendor-dir /home/russell/projects/esp-temperature/vendor/ --output-dir /home/russell/projects/esp-temperature/lib/generated/
Run Build- DEBUG: Package 'nb' has 0 dependencies and 1 dependents
Run Build- DEBUG: Package 'void' has 0 dependencies and 1 dependents
Run Build- DEBUG: Package 'embedded-hal' has 2 dependencies and 2 dependents
Run Build- DEBUG: Package 'libc' has 0 dependencies and 2 dependents
Run Build- DEBUG: Package 'esp8266-hal' has 2 dependencies and 1 dependents
Run Build- DEBUG: Package 'esp-temperature' has 3 dependencies and 0 dependents
Run Build- DEBUG: TODO: 'rerun-if-changed' = 'build.rs'
Run Build- DEBUG: Building /home/russell/projects/esp-temperature/lib/generated/liblibc-0_2_45.hir - Missing
BUILDING libc from libc v0.2.45 with features []
Run Build- Calling /home/russell/.esp-rs/mrustc/bin/mrustc /home/russell/projects/esp-temperature/vendor/libc/src/lib.rs --crate-name libc --crate-type rlib --crate-tag 0_2_45 -g --cfg debug_assertions -O -o /home/russell/projects/esp-temperature/lib/generated/liblibc-0_2_45.hir -L /home/russell/projects/esp-temperature/lib/generated --cfg stdbuild -L /home/russell/.esp-rs/mrustc/output
Run Build- DEBUG: Environment { OUT_DIR=/home/russell/projects/esp-temperature/lib/generated/build_libc CARGO_MANIFEST_DIR=/home/russell/projects/esp-temperature/vendor/libc CARGO_PKG_VERSION=0.2.45 CARGO_PKG_VERSION_MAJOR=0 CARGO_PKG_VERSION_MINOR=2 CARGO_PKG_VERSION_PATCH=45 }
terminate called after throwing an instance of 'ParseError::Unexpected'
  what():  std::exception
Run Build- DEBUG: Compiler was terminated with signal 6
Run Build- DEBUG: See /home/russell/projects/esp-temperature/lib/generated/liblibc-0_2_45.hir_dbg.txt for the compiler output
BUILD FAILED
```

It seems that the directive `align` in lines like this one are causing the problem
```
 #[cfg_attr(feature = "align", repr(align(4)))]
```

The error output in `liblibc-0_2_45.hir_dbg.txt` looks like
```
Parse: V V V
(0.00 s) Parse: DONE
LoadCrates: V V V
(0.07 s) LoadCrates: DONE
Expand: V V V
/home/russell/projects/esp-temperature/vendor/libc/src/unix/mod.rs:135: Unexpected(TOK_INTEGER:4, TOK_IDENT)
```