### PR TITLE
Fixes for MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ esp-rs/build.sh --install
 ```
 Note: Under MacOS it is possible in some cases that the Python path is not set correctly. So plattformio is installed but not found. This must be fixed manually, e.g. by adding the /etc/paths.d/python.
 
+Note: Under MacOS it is possible that bash < 4.0 is installed. The build script requires Bash 4.0 functions.
+
 ## Updating
 
 This may take a while also if `mrustc` needs to be recompiled. If, for some

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ This will take a while since it needs to compile `mrustc`.
 git clone https://github.com/emosenkis/esp-rs.git
 esp-rs/build.sh --install
 ```
+Note: Under MacOS it is possible in some cases that the Python path is not set correctly. So plattformio is installed but not found. This must be fixed manually, e.g. by adding the /etc/paths.d/python.
 
 ## Updating
 

--- a/build.sh
+++ b/build.sh
@@ -2,7 +2,7 @@
 
 set -e -u -o pipefail
 
-readonly MRUSTC_VER='b5b7089'
+readonly MRUSTC_VER='master'
 readonly SDK_VER='2.4.1'
 
 readonly INSTALL_DIR="${HOME}/.esp-rs"
@@ -74,7 +74,7 @@ function install_toolchain() {
 
     checkout_git_revision 'https://github.com/thepowersgang/mrustc.git' "${MRUSTC_VER}" "${MRUSTC_DIR}" 'mrustc'
     echo "Building mrustc/minicargo@${MRUSTC_VER}"
-    ( cd "${MRUSTC_DIR}" && make RUSTCSRC && make -f minicargo.mk PARLEVEL=$(processor_count) LIBS )
+    ( cd "${MRUSTC_DIR}" && make -j $(processor_count) RUSTCSRC && make -f minicargo.mk PARLEVEL=$(processor_count) LIBS )
     checkout_git_revision 'https://github.com/esp8266/Arduino.git' "${SDK_VER}" "${SDK_ROOT}" 'ESP8266 Arduino SDK'
     if ! [[ -d "${TOOLCHAIN_ROOT}" ]]; then
         echo 'Installing PlatformIO ESP8266 Arduino SDK...'

--- a/build.sh
+++ b/build.sh
@@ -11,6 +11,15 @@ readonly SDK_ROOT="${INSTALL_DIR}/esp8266-arduino"
 readonly TOOLCHAIN_ROOT="${HOME}/.platformio/packages/toolchain-xtensa"
 readonly PROJECT_DIR="${PWD}"
 
+function processor_count() {
+    OSTYPE=`uname`
+    if [[ "$OSTYPE" == "Darwin" ]]; then
+        return `sysctl -n hw.physicalcpu`
+    else
+        return `nproc`
+    fi
+}
+
 function main() {
     if [[ "${1:-}" == '--install' ]]; then
         install_toolchain
@@ -65,7 +74,7 @@ function install_toolchain() {
 
     checkout_git_revision 'https://github.com/thepowersgang/mrustc.git' "${MRUSTC_VER}" "${MRUSTC_DIR}" 'mrustc'
     echo "Building mrustc/minicargo@${MRUSTC_VER}"
-    ( cd "${MRUSTC_DIR}" && make RUSTCSRC && make -f minicargo.mk PARLEVEL=$(nproc) LIBS )
+    ( cd "${MRUSTC_DIR}" && make RUSTCSRC && make -f minicargo.mk PARLEVEL=$(processor_count) LIBS )
     checkout_git_revision 'https://github.com/esp8266/Arduino.git' "${SDK_VER}" "${SDK_ROOT}" 'ESP8266 Arduino SDK'
     if ! [[ -d "${TOOLCHAIN_ROOT}" ]]; then
         echo 'Installing PlatformIO ESP8266 Arduino SDK...'


### PR DESCRIPTION
MRUSTC_VER have to be "master". I think we should discuss this, because I don't know how stable is the master branch.

nproc is not available on macOS, so I created a simple helper function.